### PR TITLE
Python 3

### DIFF
--- a/linux/install/patch-list
+++ b/linux/install/patch-list
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import re
 

--- a/linux/install/patch-xml
+++ b/linux/install/patch-xml
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import re
 


### PR DESCRIPTION
Seems recent Ubuntu distributive have no python binaries by default, only python3.